### PR TITLE
use cursor position as zoom center

### DIFF
--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -630,6 +630,12 @@ class ImageViewer extends HTMLElement {
     const newScale = this.currentScale + delta;
 
     if (newScale >= this.config.minScale && newScale <= this.config.maxScale) {
+      const ratio = newScale / this.currentScale;
+      const offsetX = e.clientX - window.innerWidth / 2;
+      const offsetY = e.clientY - window.innerHeight / 2;
+
+      this.currentX = offsetX * (1 - ratio) + this.currentX * ratio;
+      this.currentY = offsetY * (1 - ratio) + this.currentY * ratio;
       this.currentScale = newScale;
       this.updateImageTransform();
     }

--- a/src/image-viewer.js
+++ b/src/image-viewer.js
@@ -631,8 +631,10 @@ class ImageViewer extends HTMLElement {
 
     if (newScale >= this.config.minScale && newScale <= this.config.maxScale) {
       const ratio = newScale / this.currentScale;
-      const offsetX = e.clientX - window.innerWidth / 2;
-      const offsetY = e.clientY - window.innerHeight / 2;
+      const rect = this.overlay.getBoundingClientRect();
+
+      const offsetX = e.clientX - (rect.left + rect.width / 2);
+      const offsetY = e.clientY - (rect.top + rect.height / 2);
 
       this.currentX = offsetX * (1 - ratio) + this.currentX * ratio;
       this.currentY = offsetY * (1 - ratio) + this.currentY * ratio;


### PR DESCRIPTION
使用滚轮缩放图片时，会以光标的位置作为中心进行缩放

更新：偏移量计算现在基于 `overlay` 容器，防止 viewer 不能铺满整个屏幕或添加了其他会影响布局的组件时，没法正常以光标的位置作为缩放中心